### PR TITLE
Update OpenJDK packages

### DIFF
--- a/packages_files/basic.apt.lst
+++ b/packages_files/basic.apt.lst
@@ -2,8 +2,8 @@
 "C compiler (GNU)" gcc
 "General purpose debugger (GNU)" gdb
 "DDD graphical front end debugger (GNU)" ddd
-"Java runtime" default-jre openjdk-11-jre openjdk-8-jre openjdk-7-jre
-"Java jdk" default-jdk openjdk-11-jdk openjdk-8-jdk openjdk-7-jdk
+"Java runtime" openjdk-21-jre openjdk-17-jre default-jre openjdk-11-jre openjdk-8-jre openjdk-7-jre
+"Java jdk" openjdk-21-jdk openjdk-17-jdk default-jdk openjdk-11-jdk openjdk-8-jdk openjdk-7-jdk
 "JavaFX" openjfx
 "Java Checkstyle" checkstyle
 "Junit framework" junit4 junit

--- a/packages_files/basic.dnf.lst
+++ b/packages_files/basic.dnf.lst
@@ -1,7 +1,7 @@
 # Basic packages for VPL jail system on Linux using DNF (fedora, etc.)
 "General purpose debugger (GNU)" gdb
 "DDD graphical front end debugger (GNU)" ddd
-"Java (OpenJDK)" java-17-openjdk-devel java-11-openjdk-devel java-1.8.0-openjdk-devel java-1.7.0-openjdk-devel
+"Java (OpenJDK)" java-21-openjdk-devel java-17-openjdk-devel java-11-openjdk-devel java-1.8.0-openjdk-devel java-1.7.0-openjdk-devel
 "JavaFX" openjfx
 "Junit framework" junit
 "PHP interpreter" php-cli


### PR DESCRIPTION
- Java 21
- Java 17 (Debian/Ubuntu only)

default JDK is 11 in Ubuntu 22.04 (too old to make default) and isn't updated once a distro is released.

We should add new versions every 2 years like LTS of .NET and Node.
Also we should let students/learners use as new versions as possible.
We may be able to remove Java 7/8 packages now or in the future because they're too old.