### PR TITLE
Install .NET SDK 10 in Ubuntu/Debian

### DIFF
--- a/packages_files/standard.apt.lst
+++ b/packages_files/standard.apt.lst
@@ -1,7 +1,7 @@
 # Standard packages for VPL jail system on Linux using APT (Debian, Ubuntu, etc.)
 "Ada compiler (GNU)" gnat
 "Assembler" nasm
-"C#/F#/VisualBasic on DotNet" dotnet-sdk-9.0 dotnet-sdk-8.0 dotnet-sdk-7.0 dotnet-sdk-6.0 mono-complete
+"C#/F#/VisualBasic on DotNet" dotnet-sdk-10.0 dotnet-sdk-9.0 dotnet-sdk-8.0 dotnet-sdk-7.0 dotnet-sdk-6.0 mono-complete
 "Fortran compiler (GNU)" gfortran
 "Haskell" hgc hugs
 "JavaScript (Nodejs)" nodejs


### PR DESCRIPTION
https://packages.ubuntu.com/search?suite=all&arch=any&searchon=names&keywords=dotnet-sdk-10.0

.NET SDK 10 is available in Ubuntu. It has already been added in the list for Fedora/RHEL.